### PR TITLE
Add fallback NotoSans-Regular.ttf path for Fedora

### DIFF
--- a/Source/GUI/GUI.cpp
+++ b/Source/GUI/GUI.cpp
@@ -28,8 +28,16 @@ void Gui::Create()
 
 	const float fontSize = 24.0f;
 	// Might not work on certain distros/configurations
-	if (!io.Fonts->AddFontFromFileTTF(xorstr_("/usr/share/fonts/noto/NotoSans-Regular.ttf"), fontSize))
-		io.Fonts->AddFontDefault();
+	for (const std::string& path : {
+			 xorstr_("/usr/share/fonts/noto/NotoSans-Regular.ttf"),
+			 xorstr_("/usr/share/fonts/google-noto/NotoSans-Regular.ttf"),
+			 xorstr_("") }) {
+		if (path.empty()) {
+			io.Fonts->AddFontDefault();
+		} else if (access(path.c_str(), F_OK) == 0 && io.Fonts->AddFontFromFileTTF(path.c_str(), fontSize)) {
+			break;
+		}
+	}
 
 	io.IniFilename = nullptr;
 	io.LogFilename = nullptr;


### PR DESCRIPTION
$ dnf provides /usr/share/fonts/google-noto/NotoSans-Regular.ttf Last metadata expiration check: 7 days, 8:10:16 ago on Sun 16 Apr 2023 12:04:21 PM CEST. google-noto-sans-fonts-20230201-1.fc38.noarch : Noto Sans font
Repo        : @System
Matched from:
Filename    : /usr/share/fonts/google-noto/NotoSans-Regular.ttf