### PR TITLE
Readd xorstr to convar names

### DIFF
--- a/Source/ConVarStorage.cpp
+++ b/Source/ConVarStorage.cpp
@@ -1,10 +1,11 @@
 #include "ConVarStorage.hpp"
 
 #include "Interfaces.hpp"
+#include <unordered_map>
 
 ConVar* ConVarStorage::GetConVar(const char* name)
 {
-	static std::map<const char*, ConVar*> conVarMap{};
+	static std::unordered_map<std::string, ConVar*> conVarMap{};
 
 	if (!conVarMap.contains(name))
 		conVarMap[name] = Interfaces::icvar->FindVar(name);

--- a/Source/ConVarStorage.hpp
+++ b/Source/ConVarStorage.hpp
@@ -5,11 +5,11 @@
 
 #include "xorstr.hpp"
 
-#define LAZY_CONVAR(name)        \
-	inline ConVar* name()        \
-	{                            \
-		return GetConVar(#name); \
-	} // TODO Why does xorstr_ not work here?
+#define LAZY_CONVAR(name)                 \
+	inline ConVar* name()                 \
+	{                                     \
+		return GetConVar(xorstr_(#name)); \
+	}
 
 namespace ConVarStorage {
 


### PR DESCRIPTION
`conVarMap` stored `const char*` as keys. This caused two issues:
1. The result of `xorstr_` was stored, but the pointer could be invalidated once the call to `GetConVar` was finished.
2. The comparison of map keys was done as pointers. While that technically works (without `xorstr_`), it is probably UB.

Even though issue 1. suggests wrapping the result of `xorstr_` into a `strdup`, this doesn't work either because of issue 2.
The simplest solution is to do proper comparison of `std::strings`. Also, `std::unordered_map` is usually faster than `std::map` so I changed that as well.