### PR TITLE
Add debian stable to ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,12 @@ jobs:
   build:
     strategy:
       matrix:
-        distro: ["ubuntu:latest", "debian:unstable", "debian:testing", "dockerscripts/linuxmint:mate", "archlinux:latest", "manjarolinux/base:latest", "fedora:latest", "opensuse/tumbleweed:latest"]
+        distro: ["ubuntu:latest", "debian:latest", "debian:unstable", "debian:testing", "dockerscripts/linuxmint:mate", "archlinux:latest", "manjarolinux/base:latest", "fedora:latest", "opensuse/tumbleweed:latest"]
       fail-fast: false
     runs-on: ubuntu-latest
     container: ${{ matrix.distro }}
     steps:
-      - if: matrix.distro == 'ubuntu:latest' || matrix.distro == 'debian:unstable' || matrix.distro == 'debian:testing' || matrix.distro == 'dockerscripts/linuxmint:mate'
+      - if: matrix.distro == 'ubuntu:latest' || matrix.distro == 'debian:unstable' || matrix.distro == 'debian:testing' || matrix.distro == 'debian:latest' || matrix.distro == 'dockerscripts/linuxmint:mate'
         name: Setup dependencies
         run: |
           apt-get update

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ A fully-featured training software for Counter Strike: Global Offensive, made fo
 Gentoo/Portage Users might want to use [this](https://github.com/Sumandora/portage-framework) ebuild repository.
 
 ### Dependencies
-**Ubuntu / Debian unstable / Debian testing / Linux Mint**
-
-Debian stable is not supported until debian 12 releases due to outdated gcc and cmake.
+**Ubuntu / Debian / Linux Mint**
 ```sh
 apt-get install gdb git cmake make build-essential libsdl2-dev
 ```
@@ -20,7 +18,7 @@ pacman -S base-devel cmake gdb git sdl2
 ```sh
 dnf install gdb git cmake make gcc-c++ SDL2-devel
 ```
-**OpenSUSE Leap**
+**OpenSUSE Tumbleweed**
 ```sh
 zypper install patchelf gdb git cmake make gcc-c++ SDL2-devel
 ```


### PR DESCRIPTION
Debian 12 has finally released, can be used now.