### PR TITLE
Add overwrite button for current config

### DIFF
--- a/Source/GUI/Construction/Windows/Configuration.cpp
+++ b/Source/GUI/Construction/Windows/Configuration.cpp
@@ -92,4 +92,13 @@ void Gui::Windows::Configuration()
 		}
 	}
 	ImGui::PopItemWidth();
+	if(configSelected >= 0 && configSelected < (int)configs.size()){
+		const char* configName = configs[configSelected].c_str();
+		if(ImGui::Button(xorstr_("Overwrite config"))){
+			if (Serialization::Save(GetConfigFile(configName)))
+				eventLog.CreateReport(xorstr_("Saved config '%s'"), configName);
+			else
+			eventLog.CreateReport(xorstr_("Failed to saved config '%s'"), configName);
+		}
+	}
 }


### PR DESCRIPTION
Allows you to overwrite the current loaded config with your current settings.

Typing in the config name every time isn't really practical if you would like config names to represent anything.

Duplicate code yes but saving could be moved to its own function if needed.